### PR TITLE
Fix Issue #1: Failure reading data from .bed files

### DIFF
--- a/R/read.haplo.bedfile.R
+++ b/R/read.haplo.bedfile.R
@@ -24,9 +24,10 @@ read.haplo.bedfile <- function(filename = "NULL",
                                   map[, 3] < endpos),
                     2]
 
-    plink.input <- snpStats::read.plink(bed = paste0(filename, ".bed"),
-                                        bim = paste0(filename, ".bim"),
-                                        fam = paste0(filename, ".fam"),
+    basefile <- sub(".bed$", "", filename)
+    plink.input <- snpStats::read.plink(bed = paste0(basefile, ".bed"),
+                                        bim = paste0(basefile, ".bim"),
+                                        fam = paste0(basefile, ".fam"),
                                         select.snps = snps2out)
 
     # TODO: added rownames(GenotyMatrix) <- idNames may requied


### PR DESCRIPTION
Since 'filename' contains the full filename/path to the .bed file, the
basename of the file should be used when calling snpStats::read.plink().
